### PR TITLE
Stable rebuild

### DIFF
--- a/org.pjbroad.EternallandsClient.appdata.xml
+++ b/org.pjbroad.EternallandsClient.appdata.xml
@@ -28,7 +28,7 @@
 	</description>
 	<translation/>
 	<releases>
-		<release version="1.9.6.1" date="2022-03-14"/>
+		<release version="1.9.6.1 dev" date="2022-10-10"/>
 	</releases>
 	<screenshots>
 		<screenshot>

--- a/org.pjbroad.EternallandsClient.json
+++ b/org.pjbroad.EternallandsClient.json
@@ -2,7 +2,7 @@
 	"app-id": "org.pjbroad.EternallandsClient",
 	"runtime": "org.freedesktop.Platform",
 	"sdk": "org.freedesktop.Sdk",
-	"runtime-version": "20.08",
+	"runtime-version": "21.08",
 	"command": "launcher.sh",
 	"finish-args": [
 		"--share=ipc",


### PR DESCRIPTION
Rebuild of stable release to update runtime.
    * Fix lint errors for cleanup.
    * Use fallback-x11.
    * Can have only one licence reference.
